### PR TITLE
compatibility with SAS drives

### DIFF
--- a/disk-burnin.sh
+++ b/disk-burnin.sh
@@ -309,13 +309,13 @@ readonly SMART_CAPABILITIES="$(smartctl --capabilities "${DRIVE}")"
 #   Write value to stdout.
 ##################################################
 get_smart_info_value() {
-  # $1=$2="";                     select all but first two columns
+  # gsub(/^.*?:/, "");            discard everything until first colon
   # gsub(/^[ \t]+|[ \t]+$/, "");  replace leading and trailing whitespace
   # gsub(/ /, "_");               replace remaining spaces with underscores
   # printf $1                     print result without newline at the end
   printf '%s' "${SMART_INFO}" \
-    | grep "$1" \
-    | awk '{$1=$2=""; gsub(/^[ \t]+|[ \t]+$/, ""); gsub(/ /, "_"); printf $1}'
+    | grep -i "$1" \
+    | awk '{gsub(/^.*?:/, ""); gsub(/^[ \t]+|[ \t]+$/, ""); gsub(/ /, "_"); printf $1}'
 }
 
 ##################################################
@@ -340,9 +340,10 @@ get_smart_test_duration() {
 }
 
 # Get disk model
-DISK_MODEL="$(get_smart_info_value "Device Model")"
-[ -z "${DISK_MODEL}" ] && DISK_MODEL="$(get_smart_info_value "Model Family")"
-[ -z "${DISK_MODEL}" ] && DISK_MODEL="$(get_smart_info_value "Model Number")"
+DISK_MODEL="$(get_smart_info_value "Device Model:")"
+[ -z "${DISK_MODEL}" ] && DISK_MODEL="$(get_smart_info_value "Model Family:")"
+[ -z "${DISK_MODEL}" ] && DISK_MODEL="$(get_smart_info_value "Model Number:")"
+[ -z "${DISK_MODEL}" ] && DISK_MODEL="$(get_smart_info_value "Product:")"
 readonly DISK_MODEL
 
 # Get disk type; unless we get 'Solid State Device' as return value, assume 
@@ -508,17 +509,17 @@ poll_selftest_complete() {
   l_poll_duration_seconds=0
   while [ "${l_poll_duration_seconds}" -lt "${POLL_TIMEOUT_SECONDS}" ]; do
     smartctl --all "${DRIVE}" \
-      | grep -i "The previous self-test routine completed" > /dev/null 2>&1
-    l_status="$?"
-    if [ "${l_status}" -eq 0 ]; then
-      log_info "SMART self-test succeeded"
-      return 0
-    fi
-    smartctl --all "${DRIVE}" \
       | grep -i "of the test failed\." > /dev/null 2>&1
     l_status="$?"
     if [ "${l_status}" -eq 0 ]; then
       log_info "SMART self-test failed"
+      return 0
+    fi
+    smartctl --all "${DRIVE}" \
+      | grep -E "Self-test execution status:.*(progress|remaining)" > /dev/null 2>&1
+    l_status="$?"
+    if [ "${l_status}" -ne 0 ]; then
+      log_info "SMART self-test succeeded"
       return 0
     fi
     sleep "${POLL_INTERVAL_SECONDS}"


### PR DESCRIPTION
Problem:
In the current version, my SAS drive had empty fields:
* Drive Model
* Serial Number
* Short/Extended test duration The script got stuck after the first SMART short test, reporting it would wait for 0 seconds.


Assumptions:
* smartctl reports different values in different fields on SAS drives (e.g. smartctl --capabilities only reports "SCSI device successfully opened")
* Every drive offers a "short" test. SAS drives do not provide information about that
* Every drive offers a "long" test. ATA drives will translate this into "extended"
* A burn-in is not time critical but must be exhaustive


Actions:
* Made grep case insensitive for Serial number on SAS vs Serial Number on ATA
* Changed "discard first two columns" to "discard everything until first colon" in get_smart_info_value
* Added colon at the end of every inquired smart info
* Changed test behavior "if success in smartctl then success; else if error in smartctl then error" to "if ATA error in smartctl then error; else if no test in progress then success" in poll_selftest_complete


Remaining problems:
* For SAS drives it will still print and log "waiting 0 seconds for test completion"


Propositions:
* Show Progress of SMART Test / remaining % instead of a fixed "waiting for ### seconds"
* Print and log actual time until completion instead of reported test duration, or maybe both
* As even SAS drives report a "long test duration", POLL_TIMEOUT_SECONDS could be set relative to that (like 1.5x), and not fixed to 4 hours.
* Maybe warn on POLL_TIMEOUT and report time tested until now, instead of abort?
* Switch to some other output form of smartctl, like json, and parse it with something like jq


INFO ABOUT RUNNING TEST:
SAS running short test
```
smartctl -l selftest /dev/sdc
smartctl 7.2 2020-12-30 r5155 [x86_64-linux-5.14.15-arch1-1] (local build) Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF READ SMART DATA SECTION ===
Self-test execution status:             84% of test remaining
SMART Self-test log
Num  Test              Status                 segment  LifeTime  LBA_first_err [SK ASC ASQ]
     Description                              number   (hours)
# 1  Background short  Self test in progress ...   -     NOW                 - [-   -    -]
# 2  Background short  Completed                   -   29626                 - [-   -    -]
# 3  Background short  Completed                   -   29626                 - [-   -    -]
# 4  Background short  Completed                   -   29625                 - [-   -    -]
# 5  Background short  Completed                   -   29625                 - [-   -    -]
# 6  Background long   Completed                   -   29625                 - [-   -    -]
# 7  Background short  Completed                   -   29612                 - [-   -    -]
# 8  Background long   Completed                   -   29608                 - [-   -    -]

Long (extended) Self-test duration: 3772 seconds [62.9 minutes]
```

SAS not running short test: "Self-test execution status" line is missing


ATA running extended test:
```
smartctl -c /dev/sdg 
smartctl 7.2 2020-12-30 r5155 [x86_64-linux-5.14.15-arch1-1] (local build) Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF READ SMART DATA SECTION ===
General SMART Values:
Offline data collection status:  (0x05) Offline data collection activity
                                        was aborted by an interrupting command from host.
                                        Auto Offline Data Collection: Disabled.
Self-test execution status:      ( 242) Self-test routine in progress...
                                        20% of test remaining.
Total time to complete Offline 
data collection:                (   45) seconds.
Offline data collection
capabilities:                    (0x5b) SMART execute Offline immediate.
                                        Auto Offline data collection on/off support.
                                        Suspend Offline collection upon new
                                        command.
                                        Offline surface scan supported.
                                        Self-test supported.
                                        No Conveyance Self-test supported.
                                        Selective Self-test supported.
SMART capabilities:            (0x0003) Saves SMART data before entering
                                        power-saving mode.
                                        Supports SMART auto save timer.
Error logging capability:        (0x01) Error logging supported.
                                        General Purpose Logging supported.
Short self-test routine 
recommended polling time:        (   2) minutes.
Extended self-test routine
recommended polling time:        ( 113) minutes.
SCT capabilities:              (0x003d) SCT Status supported.
                                        SCT Error Recovery Control supported.
                                        SCT Feature Control supported.
                                        SCT Data Table supported.


ATA drive after abort:
Self-test execution status:      (  25)	The self-test routine was aborted by
					the host.


ATA drive after successful short test:
Self-test execution status:      (   0)	The previous self-test routine completed
					without error or no self-test has ever 
					been run.
```

SMART INFO ON SAS DRIVE
```
# echo $SMART_INFO
smartctl 7.2 2020-12-30 r5155 [x86_64-linux-5.14.15-arch1-1] (local build)
Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org
                                                                                                         
=== START OF INFORMATION SECTION ===       
Vendor:               TOSHIBA                                                                            
Product:              AL13SXB600N
Revision:             5202                                                                               
Compliance:           SPC-3                                                                              
User Capacity:        600,127,266,816 bytes [600 GB]                          
Logical block size:   512 bytes                                                                          
Rotation Rate:        15000 rpm                                                                          
Form Factor:          2.5 inches                                                                         
Logical Unit id:      0x500003975861d374                                                                 
Serial number:        X6S0A03FFIYA                                                                       
Device type:          disk                                                                               
Transport protocol:   SAS (SPL-3)                                                                        
Local Time is:        Sat Nov 20 14:18:01 2021 UTC                                                       
SMART support is:     Available - device has SMART capability.
SMART support is:     Enabled                                                                            
Temperature Warning:  Disabled or Not Supported
```

FYI:
```
# smartctl -A /dev/sdc
smartctl 7.2 2020-12-30 r5155 [x86_64-linux-5.14.15-arch1-1] (local build) Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF READ SMART DATA SECTION ===
Current Drive Temperature:     51 C
Drive Trip Temperature:        65 C

Accumulated power on time, hours:minutes 29625:34
Manufactured in week 43 of year 2016
Specified cycle count over device lifetime:  50000 Accumulated start-stop cycles:  15
Specified load-unload count over device lifetime:  600000 Accumulated load-unload cycles:  15
Elements in grown defect list: 0
```

FYI to get info like ATA "reallocated sector" or "pending sector" os SAS devices:
```
# smartctl -l error /dev/sdc
smartctl 7.2 2020-12-30 r5155 [x86_64-linux-5.14.15-arch1-1] (local build) Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF READ SMART DATA SECTION ===
Error counter log:
           Errors Corrected by           Total   Correction     Gigabytes    Total
               ECC          rereads/    errors   algorithm      processed    uncorrected
           fast | delayed   rewrites  corrected  invocations   [10^9 bytes]  errors
read:          0     2567      1986      1986          0     993683.879           0
write:         0        0         0         0          0      49874.645           0
verify:        0        0         0         0          0     106222.531           0

Non-medium error count:        0
```